### PR TITLE
doc: add BGP config parsing overview

### DIFF
--- a/doc/developer/bgp-config-parsing.rst
+++ b/doc/developer/bgp-config-parsing.rst
@@ -1,0 +1,18 @@
+BGP Configuration Parsing
+=========================
+
+FRRouting's BGP daemon (bgpd) uses the common VTY infrastructure to parse
+configuration commands. The key files involved are:
+
+* ``lib/command.c`` – provides the shared CLI backend used by all daemons.
+* ``bgpd/bgpd.c`` – installs BGP-specific CLI commands at startup by calling
+  ``bgp_vty_init()``.
+* ``bgpd/bgp_vty.c`` – defines the main BGP configuration mode, including the
+  ``router bgp`` command.
+* ``bgpd/bgp_evpn_vty.c`` – adds EVPN-specific configuration commands such as
+  ``advertise-default-gw`` for VNIs.
+* ``bgpd/bgp_flowspec_vty.c`` – handles FlowSpec-related commands like
+  ``local-install`` for local policy routing.
+
+Together these files implement the parsing and execution of BGP configuration
+through the VTY interface.

--- a/doc/developer/index.rst
+++ b/doc/developer/index.rst
@@ -15,6 +15,7 @@ FRRouting Developer's Guide
    testing
    mgmtd-dev
    bgpd
+   bgp-config-parsing
    fpm
    grpc
    ospf

--- a/doc/developer/subdir.am
+++ b/doc/developer/subdir.am
@@ -3,6 +3,7 @@
 #
 
 dev_RSTFILES = \
+        doc/developer/bgp-config-parsing.rst \
 	doc/developer/bgp-typecodes.rst \
 	doc/developer/bgpd.rst \
 	doc/developer/bmp.rst \


### PR DESCRIPTION
## Summary
- add developer documentation for BGP configuration parsing
- link new overview in developer docs index and build scripts

## Testing
- `make developer-html` *(fails: No rule to make target 'developer-html')*
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_689cc129faa48321921d6853cf1a927f